### PR TITLE
[day22-ICO] Bugfix to be able to withdraw() after token release

### DIFF
--- a/smart-contract-30/day22-ICO/ICO.sol
+++ b/smart-contract-30/day22-ICO/ICO.sol
@@ -145,6 +145,7 @@ contract ICO {
         onlyAdmin()
         icoEnded()
         tokensNotReleased() {
+        released = true;
         ERC20Token tokenInstance = ERC20Token(token);
         for(uint i = 0; i < sales.length; i++) {
             Sale storage sale = sales[i];


### PR DESCRIPTION
updated the release boolean accordingly.
The modifiers `tokensNotReleased` and `tokensReleased`, should work accordingly now and the `withdraw()` works now as expected, only after the release function was called.